### PR TITLE
Fix TypeError returned when insufficient Authorization

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -119,7 +119,7 @@ def qbo_request(request):
     response = qbo_api_call(auth_client.access_token, auth_client.realm_id)
     
     if not response.ok:
-        return HttpResponse(' '.join([response.content, str(response.status_code)]))
+        return HttpResponse(' '.join([str(response.content), str(response.status_code)]))
     else:
         return HttpResponse(response.content)
 


### PR DESCRIPTION
If app doesn't have authentication rights, then the code sends a type error. Fixed by wrapping casting response.content to string -- user can then see the authorization error message in the app.

Error: SampleOAuth2_UsingPythonClient\app\views.py", line 122, in qbo_request
    return HttpResponse(b' '.join([response.content, str(response.status_code)]))
TypeError: sequence item 1: expected a bytes-like object, str found